### PR TITLE
fix bad alpha-blending

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,12 +205,13 @@ function color(r,g,b,a)
 */
 function blend(background, color) {
   var srcAlpha = color[3] / 255.0;
+  var dstAlpha = background[3] * (255.0 - color[3]) / 255.0;
 
   return [
-    Math.round(color[0] * srcAlpha + background[0] * (1 - srcAlpha)),
-    Math.round(color[1] * srcAlpha + background[1] * (1 - srcAlpha)),
-    Math.round(color[2] * srcAlpha + background[2] * (1 - srcAlpha)),
-    background[3]
+    Math.round((color[0] * srcAlpha) + (background[0] * dstAlpha) / 255.0),
+    Math.round((color[1] * srcAlpha) + (background[1] * dstAlpha) / 255.0),
+    Math.round((color[2] * srcAlpha) + (background[2] * dstAlpha) / 255.0),
+    Math.round(color[3] + dstAlpha),
   ];
 }
 


### PR DESCRIPTION
I found a problem trying to draw over an empty, newly created PNG with all transparent pixels. Since this package uses blend function that always takes target's alpha, I was getting an empty PNG anytime I try to draw anything. This fixes it, using proper alpha-blending function as described here: https://stackoverflow.com/questions/1944095/how-to-mix-two-argb-pixels

I have also optimized it slightly to reduce amount of computations.

I'd like to see updated version in npm too, please.